### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ I lack both the time and interest to maintain and develop latexdiffcite further.
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/latexdiffcite
 
-.. |supported-versions| image:: https://pypip.in/py_versions/latexdiffcite/badge.svg?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/latexdiffcite.svg?style=flat
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/latexdiffcite
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20latexdiffcite))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `latexdiffcite`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.